### PR TITLE
Transition to using ct_tag_id instead of named tag

### DIFF
--- a/public_html/revisions.php
+++ b/public_html/revisions.php
@@ -14,28 +14,28 @@ function make_revisions_by_user_query() {
 	if(isset($user_clause) && isset($namespaces)) {
 	  $query = "
 		SELECT g.page_id, g.page_title, g.page_namespace,
-		  c.rev_id, c.rev_timestamp, c.rev_user_text, c.rev_user,
-		  case when ct.ct_tag_id IS NULL then 'false' else 'true' end as system,
-		  case when c.rev_parent_id = 0 then 'true' else 'false' end as new_article,
-		  CAST(c.rev_len AS SIGNED) - CAST(IFNULL(p.rev_len, 0) AS SIGNED) AS byte_change
+			c.rev_id, c.rev_timestamp, c.rev_user_text, c.rev_user,
+			case when ct.ct_tag_id IS NULL then 'false' else 'true' end as system,
+			case when c.rev_parent_id = 0 then 'true' else 'false' end as new_article,
+			CAST(c.rev_len AS SIGNED) - CAST(IFNULL(p.rev_len, 0) AS SIGNED) AS byte_change
 		FROM revision_userindex c
 		LEFT JOIN revision_userindex p ON p.rev_id = c.rev_parent_id
 		INNER JOIN page g ON g.page_id = c.rev_page
 		LEFT JOIN change_tag_def ctd
-      ON ctd.ctd_name IN ($tags)
-    LEFT JOIN change_tag ct
-      ON ct.ct_rev_id = c.rev_id
-      AND ct.ct_tag_id = ctd.ctd_id
+			ON ctd.ctd_name IN ($tags)
+		LEFT JOIN change_tag ct
+			ON ct.ct_rev_id = c.rev_id
+			AND ct.ct_tag_id = ctd.ctd_id
 		WHERE g.page_namespace IN ($namespaces)
 		{$user_clause}
 		AND c.rev_timestamp BETWEEN $start AND $end
-	  ";
+		";
 	} else if(isset($sql_rev_ids)) {
 	  $query = "
 		SELECT rev_id, rev_page
 		FROM revision_userindex
 		WHERE rev_id IN ($sql_rev_ids)
-	  ";
+		";
 	}
 	return $query;
 }

--- a/public_html/revisions.php
+++ b/public_html/revisions.php
@@ -15,15 +15,17 @@ function make_revisions_by_user_query() {
 	  $query = "
 		SELECT g.page_id, g.page_title, g.page_namespace,
 		  c.rev_id, c.rev_timestamp, c.rev_user_text, c.rev_user,
-		  case when ct.ct_tag IS NULL then 'false' else 'true' end as system,
+		  case when ct.ct_tag_id IS NULL then 'false' else 'true' end as system,
 		  case when c.rev_parent_id = 0 then 'true' else 'false' end as new_article,
 		  CAST(c.rev_len AS SIGNED) - CAST(IFNULL(p.rev_len, 0) AS SIGNED) AS byte_change
 		FROM revision_userindex c
 		LEFT JOIN revision_userindex p ON p.rev_id = c.rev_parent_id
 		INNER JOIN page g ON g.page_id = c.rev_page
-		LEFT JOIN change_tag ct
-		  ON ct.ct_rev_id = c.rev_id
-		  AND ct.ct_tag IN ($tags)
+		LEFT JOIN change_tag_def ctd
+      ON ctd.ctd_name IN ($tags)
+    LEFT JOIN change_tag ct
+      ON ct.ct_rev_id = c.rev_id
+      AND ct.ct_tag_id = ctd.ctd_id
 		WHERE g.page_namespace IN ($namespaces)
 		{$user_clause}
 		AND c.rev_timestamp BETWEEN $start AND $end

--- a/tests/RevisionsByUserIdTest.php
+++ b/tests/RevisionsByUserIdTest.php
@@ -9,10 +9,10 @@ class RevisionsByUserTest extends PHPUnit_Framework_TestCase {
 		));
 		$expected = "
 			SELECT g.page_id, g.page_title, g.page_namespace,
-			  c.rev_id, c.rev_timestamp, c.rev_user_text, c.rev_user,
-			  case when ct.ct_tag_id IS NULL then 'false' else 'true' end as system,
-			  case when c.rev_parent_id = 0 then 'true' else 'false' end as new_article,
-			  CAST(c.rev_len AS SIGNED) - CAST(IFNULL(p.rev_len, 0) AS SIGNED) AS byte_change
+				c.rev_id, c.rev_timestamp, c.rev_user_text, c.rev_user,
+				case when ct.ct_tag_id IS NULL then 'false' else 'true' end as system,
+				case when c.rev_parent_id = 0 then 'true' else 'false' end as new_article,
+				CAST(c.rev_len AS SIGNED) - CAST(IFNULL(p.rev_len, 0) AS SIGNED) AS byte_change
 			FROM revision_userindex c
 			LEFT JOIN revision_userindex p ON p.rev_id = c.rev_parent_id
 			INNER JOIN page g ON g.page_id = c.rev_page
@@ -24,7 +24,7 @@ class RevisionsByUserTest extends PHPUnit_Framework_TestCase {
 			WHERE g.page_namespace IN (0,1,2,3,4,5,10,11,118,119)
 			AND c.rev_user_text IN ('Admin','北岛','Bak\'un')
 			AND c.rev_timestamp BETWEEN '20130101' AND '20170203'
-		  ";
+			";
 		$query = make_revisions_by_user_query();
 		$this->assertEquals(strip($expected), strip($query));
 	}

--- a/tests/RevisionsByUserIdTest.php
+++ b/tests/RevisionsByUserIdTest.php
@@ -10,15 +10,17 @@ class RevisionsByUserTest extends PHPUnit_Framework_TestCase {
 		$expected = "
 			SELECT g.page_id, g.page_title, g.page_namespace,
 			  c.rev_id, c.rev_timestamp, c.rev_user_text, c.rev_user,
-			  case when ct.ct_tag IS NULL then 'false' else 'true' end as system,
+			  case when ct.ct_tag_id IS NULL then 'false' else 'true' end as system,
 			  case when c.rev_parent_id = 0 then 'true' else 'false' end as new_article,
 			  CAST(c.rev_len AS SIGNED) - CAST(IFNULL(p.rev_len, 0) AS SIGNED) AS byte_change
 			FROM revision_userindex c
 			LEFT JOIN revision_userindex p ON p.rev_id = c.rev_parent_id
 			INNER JOIN page g ON g.page_id = c.rev_page
+			LEFT JOIN change_tag_def ctd
+				ON ctd.ctd_name IN ($tags)
 			LEFT JOIN change_tag ct
-			  ON ct.ct_rev_id = c.rev_id
-			  AND ct.ct_tag IN (NULL)
+				ON ct.ct_rev_id = c.rev_id
+				AND ct.ct_tag_id = ctd.ctd_id
 			WHERE g.page_namespace IN (0,1,2,3,4,5,10,11,118,119)
 			AND c.rev_user_text IN ('Admin','北岛','Bak\'un')
 			AND c.rev_timestamp BETWEEN '20130101' AND '20170203'


### PR DESCRIPTION
An update to the Wikipedia database changed the lookup for tags to use an ID instead of a tag name. This update should correctly look for the name in a joined table.
* [Working query](https://quarry.wmflabs.org/query/33029)

