### PR TITLE
fix: calculate byte change using the previous revision's length when the parent revision is missing.

### DIFF
--- a/public_html/revisions.php
+++ b/public_html/revisions.php
@@ -15,7 +15,15 @@ function make_revisions_by_user_query() {
 			c.rev_id, c.rev_timestamp, a.actor_name AS rev_user_text, a.actor_user AS rev_user,
 			case when ct.ct_tag_id IS NULL then 'false' else 'true' end as system,
 			case when c.rev_parent_id = 0 then 'true' else 'false' end as new_article,
-			CAST(c.rev_len AS SIGNED) - CAST(IFNULL(p.rev_len, 0) AS SIGNED) AS byte_change
+			CASE 
+				WHEN p.rev_len IS NOT NULL THEN CAST(c.rev_len AS SIGNED) - CAST(p.rev_len AS SIGNED)
+				ELSE CAST(c.rev_len AS SIGNED) - CAST(IFNULL(
+					(SELECT rev_len FROM revision 
+					 WHERE rev_page = c.rev_page 
+					   AND rev_id < c.rev_id 
+					 ORDER BY rev_id DESC LIMIT 1), 
+				0) AS SIGNED)
+			END AS byte_change
 		FROM revision_userindex c
 		JOIN actor a ON a.actor_id = c.rev_actor
 		LEFT JOIN revision_userindex p ON p.rev_id = c.rev_parent_id


### PR DESCRIPTION
# PR Description: Fix Inflated Character Counts for Suppressed Parent Revisions

Closes  [issue](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6331)
## Summary
This fix addresses an issue where student editor character counts were being significantly inflated (often to the entire page size) when the immediately preceding revision was deleted or suppressed on Wikipedia.

### The Bug
In `revisions.php`, the `byte_change` was calculated as `CAST(c.rev_len AS SIGNED) - CAST(IFNULL(p.rev_len, 0) AS SIGNED)`. When a parent revision is suppressed, its length returns `NULL` in the Replica database, causing the tool to subtract 0 from the current size and incorrectly attribute the entire page content to the current editor.

### The Fix
I have updated the SQL logic to use a `CASE` statement. If the direct parent's length is `NULL`, the query now uses a subquery to find the most recent surviving ancestor revision on the same page and calculates the difference from that size instead. This ensures that the statistics remain as accurate as possible even when history is suppressed.

## Verification & Testing
I verified this fix against the **English Wikipedia Replica database** on Toolforge using real suppressed revision cases (including the "Ball culture" article reported).

**Example Case: Rhitorical on "Ball culture"**
- **Revision ID:** 1278154303
- **Before Fix:** Returns `byte_change: 75839` (full page size).
<img width="1866" height="522" alt="image" src="https://github.com/user-attachments/assets/4e9961df-91b7-4b5b-b0aa-7e9d8cb95c6d" />

- **After Fix:** Returns `byte_change: 1842` (the actual difference).
<img width="1866" height="522" alt="image" src="https://github.com/user-attachments/assets/052ee43e-0ffe-458e-b09e-ad3764e93a44" />

## Performance Impact
I performed profiling on the `enwiki` replica to ensure no significant overhead was introduced. The subquery shows 1ms(average) overhead, only triggering when data is actually missing.

### **Performance Comparison**
<img width="1712" height="241" alt="image" src="https://github.com/user-attachments/assets/aec4d119-dd8d-44a0-a5a2-f3253fe2e385" />

| Revision ID | Original (Bug) Time | **New (Fixed) Time** | **Difference** |
| :--- | :--- | :--- | :--- |
| **4863** | 0.80 ms | **3.15 ms** | +2.35 ms |
| **10271** | 0.70 ms | **1.25 ms** | +0.55 ms |
| **13546** | 0.69 ms | **1.28 ms** | +0.59 ms |
| **23381** | 0.72 ms | **3.78 ms** | +3.06 ms |
| **29371** | 0.69 ms | **1.28 ms** | +0.59 ms |

