### PR TITLE
Surface replica DB connection failures as JSON instead of empty HTTP 500

### DIFF
--- a/public_html/common.php
+++ b/public_html/common.php
@@ -1,5 +1,25 @@
 <?php
 
+// Return mysqli errors as states to check (connect_errno, query() === false)
+// rather than thrown exceptions. PHP 8.1+ defaults to throwing, which would
+// turn a failed connection or query into an uncaught exception and a bare
+// HTTP 500 with an empty body; this code is written to inspect the error
+// states instead so it can report a useful message.
+mysqli_report(MYSQLI_REPORT_OFF);
+
+// Emit a JSON error body and stop, instead of letting a connection failure
+// surface as an empty HTTP 500. Uses 502 because the failure is upstream
+// (the replica database), not in this request.
+function fail_db_connection($db_name, $hostname, $error) {
+	http_response_code(502);
+	header('Content-Type: application/json');
+	echo json_encode(array(
+		"success" => false,
+		"error" => "Cannot connect to database {$db_name} on {$hostname}: {$error}"
+	));
+	exit;
+}
+
 function get_db() {
 	global $username, $password, $db_name, $wiki_name;
 
@@ -10,9 +30,9 @@ function get_db() {
 	$password = $settings['client']['password'];
 	$db_name = "{$wiki_name}_p";
 
-	$db = new mysqli($hostname, $username, $password, $db_name);
+	$db = @new mysqli($hostname, $username, $password, $db_name);
 	if ($db->connect_errno > 0) {
-	  die ("Cannot connect to database");
+	  fail_db_connection($db_name, $hostname, $db->connect_error);
 	}
 	$db->set_charset('utf8');
 	return $db;
@@ -24,9 +44,9 @@ function get_auth_db() {
 	$auth_hostname = "centralauth.labsdb";
 	$auth_db_name = "centralauth_p";
 
-	$auth_db = new mysqli($auth_hostname, $username, $password, $auth_db_name);
+	$auth_db = @new mysqli($auth_hostname, $username, $password, $auth_db_name);
 	if ($auth_db->connect_errno > 0) {
-	  die ("Cannot connect to CentralAuth database");
+	  fail_db_connection($auth_db_name, $auth_hostname, $auth_db->connect_error);
 	}
 	$auth_db->set_charset('utf8');
 	return $auth_db;


### PR DESCRIPTION
## Summary

While diagnosing #21 (ur.wikisource returning HTTP 500), we found the endpoints return a **bare HTTP 500 with an empty body** whenever a replica DB connection fails — giving the client no way to know why. This PR makes that failure self-diagnosing.

Two things combined to produce the empty 500:

1. Under **PHP 8.1+**, mysqli defaults to throwing exceptions (`MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT`), so the failing `new mysqli()` raised an **uncaught exception** before the existing `if ($db->connect_errno > 0)` guard could run. This file is written to *inspect* error states (`connect_errno`, `query() === false`), so we set `mysqli_report(MYSQLI_REPORT_OFF)` to restore that contract. As a bonus this also fixes empty 500s on failed **queries**, not just connections.
2. The `die("Cannot connect to database")` fallback emitted plain text with an HTTP **200**, which was also unhelpful.

## Behavior change

A connection failure now returns **HTTP 502** with a JSON body:

```json
{ "success": false, "error": "Cannot connect to database urwikisource_p on urwikisource.web.db.svc.wikimedia.cloud: Access denied for user 's52389'@'%' to database 'urwikisource_p'" }
```

## Root cause this surfaced (context for #21)

`ur.wikisource` is a **new wiki** (created ~April 2026) rebalanced onto section **s5** — the only tracked wikisource not on s3. Its wikireplica `urwikisource_p` views/grants have **not been created yet**, tracked upstream in [T415977](https://phabricator.wikimedia.org/T415977) (still open). So *every* tool account — including a freshly-provisioned one — gets MySQL error **1044** "Access denied ... to database `urwikisource_p`". Nothing to fix on the DB-name mapping or credentials side; it resolves when T415977 lands. This PR just makes the endpoint report the real error in the meantime.

## Note on the Sentry spam

This 502 does **not** by itself stop the Dashboard's retry/Sentry-report loop (`replica.rb` does `raise unless response.code == '200'`). Stopping that is a consumer-side mitigation. We intentionally did **not** return HTTP 200 here, since that would silently zero-out stats for every transient DB blip across all wikis.

Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)